### PR TITLE
PROD-168: Persist data between system shutdowns.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,9 +14,13 @@ security.oauth2.sso.loginPath=/authorization-code/callback
 # create-drop Creates the database then drops it when the SessionFactory closes.
 # From: https://spring.io/guides/gs/accessing-data-mysql/
 
-# !!!!! This needs to be changed
+# This setting will enable code first generation of the database tables. The database needs to
+# be created already. The database tables will be created and updated automatically. One thing to note
+# is if there is a database schema change that requires data to be restructured (tables being broken
+# down or dropped for example) then manual intervention will be needed. As a side note this implementation
+# should be reconsidered upon scaling the application. See confluence documentation for this product for more
+# details.
 spring.jpa.hibernate.ddl-auto=update
-# !!!!! This needs to be changes
 
 spring.datasource.url=jdbc:mysql://localhost:3306/FulfillmentPlatform
 spring.datasource.username=${DB_USER}


### PR DESCRIPTION
- Update application.properties database generation property to update. This will create the database if it doesn't exist and make automatic changes to the database upon model changes. This setting will not perform any operations on the database automatically that will lose data.

In the future we should look towards moving away from this method of database generation. It is useful for local testing and lower environments but production should have a database generation process that is more explicit. See PROD-168, comments, for more details.